### PR TITLE
fix(en): match DBI 898 temperature rows (literal $°$ degree escape)

### DIFF
--- a/translations/en.csv
+++ b/translations/en.csv
@@ -1242,3 +1242,27 @@ TitleId : {} BID: {},TitleId  : {} BID: {}
 Проверять хэш при установке    : ,Verify hash on install    : 
 Просмотр раздела USER          : ,Browse USER partition          : 
 Тема отображения               : ,Display theme                : 
+Температура    : {}$°$C,Temperature         : {}°C
+Температура     : {}$°$C,Temperature         : {}°C
+Температура      : {}$°$C,Temperature         : {}°C
+Температура       : {}$°$C,Temperature         : {}°C
+Температура        : {}$°$C,Temperature         : {}°C
+Температура         : {}$°$C,Temperature         : {}°C
+Температура          : {}$°$C,Temperature         : {}°C
+Температура           : {}$°$C,Temperature         : {}°C
+Температура            : {}$°$C,Temperature         : {}°C
+Температура             : {}$°$C,Temperature         : {}°C
+Температура              : {}$°$C,Temperature         : {}°C
+Срепняя температура: {}$°$C,Average temperature : {}°C
+Средняя температура: {}$°$C,Average temperature : {}°C
+Температура батареи        : {}$°$C,Battery temperature          : {}°C
+Температура батареи         : {}$°$C,Battery temperature          : {}°C
+Температура батареи          : {}$°$C,Battery temperature          : {}°C
+Температура батареи           : {}$°$C,Battery temperature          : {}°C
+Температура батареи            : {}$°$C,Battery temperature          : {}°C
+Температура батареи             : {}$°$C,Battery temperature          : {}°C
+Температура батареи              : {}$°$C,Battery temperature          : {}°C
+Температура батареи               : {}$°$C,Battery temperature          : {}°C
+Температура батареи                : {}$°$C,Battery temperature          : {}°C
+Температура батареи                 : {}$°$C,Battery temperature          : {}°C
+Температура батареи                  : {}$°$C,Battery temperature          : {}°C


### PR DESCRIPTION
DBI 898 renders the System Information temperature rows with the degree glyph wrapped in a literal $...$ escape ("Температура ... : {}$°$C"), so the existing clean-° keys never matched and those rows stayed untranslated on device.

Add the $°$ key forms, space-fanned across the label->colon alignment padding (Температура, Температура батареи) plus the runtime "Срепняя" typo variant, all mapping to the existing aligned English values.