### PR TITLE
feat(en): add DBI 905 temperature rows (clean ° degree)

### DIFF
--- a/translations/en.csv
+++ b/translations/en.csv
@@ -1242,3 +1242,24 @@ TitleId : {} BID: {},TitleId  : {} BID: {}
 Проверять хэш при установке    : ,Verify hash on install    : 
 Просмотр раздела USER          : ,Browse USER partition          : 
 Тема отображения               : ,Display theme                : 
+Температура    : {}°C,Temperature         : {}°C
+Температура     : {}°C,Temperature         : {}°C
+Температура      : {}°C,Temperature         : {}°C
+Температура       : {}°C,Temperature         : {}°C
+Температура         : {}°C,Temperature         : {}°C
+Температура          : {}°C,Temperature         : {}°C
+Температура           : {}°C,Temperature         : {}°C
+Температура            : {}°C,Temperature         : {}°C
+Температура             : {}°C,Temperature         : {}°C
+Температура              : {}°C,Temperature         : {}°C
+Температура батареи        : {}°C,Battery temperature          : {}°C
+Температура батареи         : {}°C,Battery temperature          : {}°C
+Температура батареи          : {}°C,Battery temperature          : {}°C
+Температура батареи           : {}°C,Battery temperature          : {}°C
+Температура батареи            : {}°C,Battery temperature          : {}°C
+Температура батареи              : {}°C,Battery temperature          : {}°C
+Температура батареи               : {}°C,Battery temperature          : {}°C
+Температура батареи                : {}°C,Battery temperature          : {}°C
+Температура батареи                 : {}°C,Battery temperature          : {}°C
+Температура батареи                  : {}°C,Battery temperature          : {}°C
+Срепняя температура: {}°C,Average temperature : {}°C


### PR DESCRIPTION
DBI 905 renders the System Information temperature rows with a clean degree glyph ("Температура ... : {}°C", no $ escape) and uses the correct "Средняя" spelling. The base already carries three exact clean-° forms; add the space-fanned variants (Температура, Температура батареи) plus "Средняя"/"Срепняя" so the rows keep translating across the label->colon alignment padding.

English values are unchanged from the existing temperature rows.

Works with patched DBI 905: https://github.com/0xroast/dbi-translate
Feel free to test and release here with your translations.